### PR TITLE
Removed error messages if not trying to save anything

### DIFF
--- a/ParrelSync/Editor/AssetModBlock/ParrelSyncAssetModificationProcessor.cs
+++ b/ParrelSync/Editor/AssetModBlock/ParrelSyncAssetModificationProcessor.cs
@@ -11,7 +11,7 @@ namespace ParrelSync
     {
         public static string[] OnWillSaveAssets(string[] paths)
         {
-            if (ClonesManager.IsClone())
+            if (paths != null && paths.Length > 0 && ClonesManager.IsClone())
             {
                 if (!EditorQuit.IsQuiting)
                 {


### PR DESCRIPTION
We detected this error using FMOD at the same time as ParrelSync

As we create a clone for the project, the clone keeps alerting us that assets are being modified (due to FMOD) and blocked by parrelSync. The problem is that the popUp doesn't let us play because once we close the popup, it opens again in 2 or 3 seconds.

Some code is calling this method constantly, but we saw that it was not giving any path in the parameter, so we tried avoiding the error messages if there are no paths and all seems to work fine.