### PR TITLE
fix: #48 package-lock.json is not synchronized when build failed

### DIFF
--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -157,6 +157,8 @@ namespace ParrelSync
                 return;
             }
 
+            ParrelSync.NonCore.ValidateCopiedFoldersIntegrity.ValidateFolder(projectPath, ClonesManager.GetOriginalProjectPath(), "Packages");
+
             string fileName = GetApplicationPath();
             string args = "-projectPath \"" + projectPath + "\"";
             Debug.Log("Opening project \"" + fileName + " " + args + "\"");

--- a/ParrelSync/Editor/ValidateCopiedFoldersIntegrity.cs
+++ b/ParrelSync/Editor/ValidateCopiedFoldersIntegrity.cs
@@ -23,16 +23,16 @@ namespace ParrelSync.NonCore
                 SessionState.SetBool(SessionStateKey, true);
                 if (!ClonesManager.IsClone()) { return; }
 
-                ValidateFolder("Packages");
+                ValidateFolder(ClonesManager.GetCurrentProjectPath(), ClonesManager.GetOriginalProjectPath(), "Packages");
             }
         }
 
-        static void ValidateFolder(string folderName)
+        public static void ValidateFolder(string current, string original, string folderName)
         {
-            var currentProjectPath = Path.Combine(ClonesManager.GetCurrentProjectPath(), folderName);
+            var currentProjectPath = Path.Combine(current, folderName);
             var currentFolderHash = CreateMd5ForFolder(currentProjectPath);
 
-            var originalProjectPath = Path.Combine(ClonesManager.GetOriginalProjectPath(), folderName);
+            var originalProjectPath = Path.Combine(original, folderName);
             var originalFolderHash = CreateMd5ForFolder(originalProjectPath);
 
             if (currentFolderHash != originalFolderHash)


### PR DESCRIPTION
I was unsure of the implementation policy, so I modified it so that it would require the min amount of changes.