### PR TITLE
Fixed bug preventing creation of a clone

### DIFF
--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -594,6 +594,8 @@ namespace ParrelSync
         private static long GetDirectorySize(DirectoryInfo directory, bool includeNested = false,
             string progressBarPrefix = "")
         {
+            if (!directory.Exists) return 0;
+            
             EditorUtility.DisplayProgressBar(progressBarPrefix + "Calculating size of directories...",
                 "Scanning '" + directory.FullName + "'...", 0f);
 

--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -551,6 +551,8 @@ namespace ParrelSync
             /// Copy all files from the source.
             foreach (FileInfo file in source.GetFiles())
             {
+                if (!file.Exists) continue;
+                
                 try
                 {
                     file.CopyTo(Path.Combine(destination.ToString(), file.Name), true);
@@ -596,7 +598,7 @@ namespace ParrelSync
                 "Scanning '" + directory.FullName + "'...", 0f);
 
             /// Calculate size of all files in directory.
-            long filesSize = directory.GetFiles().Sum((FileInfo file) => file.Length);
+            long filesSize = directory.GetFiles().Sum((FileInfo file) => file.Exists ? file.Length : 0);
 
             /// Calculate size of all nested directories.
             long directoriesSize = 0;


### PR DESCRIPTION
If for some reason a file from the source does not exist, we get an error in the console and we get stucked on importing assets like described in this issue : https://github.com/VeriorPies/ParrelSync/issues/56