### PR TITLE
added Sync Packages Folder button

### DIFF
--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -266,6 +266,19 @@ namespace ParrelSync
             }
         }
 
+        public static void SyncPackages(string cloneProjectPath)
+        {
+            if (string.IsNullOrEmpty(cloneProjectPath)) return;
+            
+            var sourceProjectPath = GetOriginalProjectPath();
+            if (cloneProjectPath == sourceProjectPath) return;
+
+            var sourceProject = new Project(sourceProjectPath);
+            var cloneProject = new Project(cloneProjectPath);
+
+            FileUtil.ReplaceDirectory(sourceProject.packagesPath, cloneProject.packagesPath);
+        }
+
         #endregion
 
         #region Creating project folders

--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -270,11 +270,11 @@ namespace ParrelSync
         {
             if (string.IsNullOrEmpty(cloneProjectPath)) return;
             
-            var sourceProjectPath = GetOriginalProjectPath();
+            string sourceProjectPath = GetOriginalProjectPath();
             if (cloneProjectPath == sourceProjectPath) return;
 
-            var sourceProject = new Project(sourceProjectPath);
-            var cloneProject = new Project(cloneProjectPath);
+            Project sourceProject = new Project(sourceProjectPath);
+            Project cloneProject = new Project(cloneProjectPath);
 
             FileUtil.ReplaceDirectory(sourceProject.packagesPath, cloneProject.packagesPath);
         }

--- a/ParrelSync/Editor/ClonesManagerWindow.cs
+++ b/ParrelSync/Editor/ClonesManagerWindow.cs
@@ -167,9 +167,16 @@ namespace ParrelSync
                                 ClonesManager.DeleteClone(cloneProjectPath);
                             }
                         }
-
                         GUILayout.EndHorizontal();
                         EditorGUI.EndDisabledGroup();
+
+                        GUILayout.BeginHorizontal();
+                        if (GUILayout.Button("Sync Packages Folder"))
+                        {
+                            ClonesManager.SyncPackages(cloneProjectPath);
+                        }
+
+                        GUILayout.EndHorizontal();
                         GUILayout.EndVertical();
 
                     }


### PR DESCRIPTION
Allows the user to sync the packages folder in the clone project with the original project by clicking a button in the ClonesManagerWindow, which is very useful when developing embedded packages.

I've noticed there have been multiple requests and PRs for this feature, and it would be very useful to me since I frequently work on embedded packages for my projects, so here's my take on implementing it. Just a simple button on the original project's ClonesManagerWindow that copies/replaces the Packages folder in the clone project with the Packages folder from the original project.

I don't believe this is an acceptable work around. Closing and reopening the project takes time and hinders rapid iteration during development: https://github.com/VeriorPies/ParrelSync/wiki/Troubleshooting-&-FAQs#why-isnt-my-newly-installed-package-being-synced-to-clone-editors

Benefits are
1. No more weird/misleading behavior when you forget that your clones and original have separate package versions (esp. when developing embedded packages). It's a good sanity check when debugging.
2. The developer has full control over when the sync happens. 
3. There is less "mental overhead" than a symlink, it's a straight copy.

![Screenshot 2022-10-16 170142](https://user-images.githubusercontent.com/8916588/196062675-95cff92d-4026-4ea9-b0e5-1b26ff0dc878.png)
