### PR TITLE
Feature add additional folders for symlinks

### DIFF
--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -114,6 +114,15 @@ namespace ParrelSync
             ClonesManager.LinkFolders(sourceProject.projectSettingsPath, cloneProject.projectSettingsPath);
             ClonesManager.LinkFolders(sourceProject.autoBuildPath, cloneProject.autoBuildPath);
             ClonesManager.LinkFolders(sourceProject.localPackages, cloneProject.localPackages);
+            foreach (var optionalPath in Preferences.OptionalSymbolicLinkFolders.Value)
+            {
+                var sourceOptionalPath = optionalPath;
+                var cloneOptionalPath = optionalPath.Replace(sourceProjectPath, cloneProjectPath);
+                Debug.Log("Linking: ");
+                Debug.Log(sourceOptionalPath);
+                Debug.Log(cloneOptionalPath);
+                ClonesManager.LinkFolders(sourceOptionalPath, cloneOptionalPath);
+            }
 
             ClonesManager.RegisterClone(cloneProject);
 

--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -114,11 +114,23 @@ namespace ParrelSync
             ClonesManager.LinkFolders(sourceProject.projectSettingsPath, cloneProject.projectSettingsPath);
             ClonesManager.LinkFolders(sourceProject.autoBuildPath, cloneProject.autoBuildPath);
             ClonesManager.LinkFolders(sourceProject.localPackages, cloneProject.localPackages);
-            foreach (var optionalPath in Preferences.OptionalSymbolicLinkFolders.GetStoredValue())
+            
+            //Optional Link Folders
+            var optionalLinkPaths = Preferences.OptionalSymbolicLinkFolders.GetStoredValue();
+            var projectSettings = ParrelSyncProjectSettings.GetSerializedSettings();
+            var projectSettingsProperty = projectSettings.FindProperty("m_OptionalSymbolicLinkFolders");
+            if (projectSettingsProperty is { isArray: true, arrayElementType: "string" })
             {
-                var sourceOptionalPath = sourceProjectPath + optionalPath;
-                var cloneOptionalPath = cloneProjectPath + optionalPath;
-                ClonesManager.LinkFolders(sourceOptionalPath, cloneOptionalPath);
+                for (var i = 0; i < projectSettingsProperty.arraySize; ++i)
+                {
+                    optionalLinkPaths.Add(projectSettingsProperty.GetArrayElementAtIndex(i).stringValue);
+                }
+            }
+            foreach (var path in optionalLinkPaths)
+            {
+                var sourceOptionalPath = sourceProjectPath + path;
+                var cloneOptionalPath = cloneProjectPath + path;
+                LinkFolders(sourceOptionalPath, cloneOptionalPath);
             }
 
             ClonesManager.RegisterClone(cloneProject);

--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -114,13 +114,10 @@ namespace ParrelSync
             ClonesManager.LinkFolders(sourceProject.projectSettingsPath, cloneProject.projectSettingsPath);
             ClonesManager.LinkFolders(sourceProject.autoBuildPath, cloneProject.autoBuildPath);
             ClonesManager.LinkFolders(sourceProject.localPackages, cloneProject.localPackages);
-            foreach (var optionalPath in Preferences.OptionalSymbolicLinkFolders.Value)
+            foreach (var optionalPath in Preferences.OptionalSymbolicLinkFolders.GetStoredValue())
             {
-                var sourceOptionalPath = optionalPath;
-                var cloneOptionalPath = optionalPath.Replace(sourceProjectPath, cloneProjectPath);
-                Debug.Log("Linking: ");
-                Debug.Log(sourceOptionalPath);
-                Debug.Log(cloneOptionalPath);
+                var sourceOptionalPath = sourceProjectPath + optionalPath;
+                var cloneOptionalPath = cloneProjectPath + optionalPath;
                 ClonesManager.LinkFolders(sourceOptionalPath, cloneOptionalPath);
             }
 

--- a/ParrelSync/Editor/ParrelSyncProjectSettings.cs
+++ b/ParrelSync/Editor/ParrelSyncProjectSettings.cs
@@ -1,0 +1,131 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace ParrelSync
+{
+    // Class name and File name MUST be identical
+    public class ParrelSyncProjectSettings : ScriptableObject
+    {
+        public const string ParrelSyncSettingsPath = "Assets/Editor/ParrelSyncProjectSettings.asset";
+        
+        [SerializeField]
+        [HideInInspector]
+        private List<string> m_OptionalSymbolicLinkFolders;
+
+        private static ParrelSyncProjectSettings GetOrCreateSettings()
+        {
+            ParrelSyncProjectSettings projectSettings;
+            if(File.Exists(ParrelSyncSettingsPath))
+            {
+                projectSettings = AssetDatabase.LoadAssetAtPath<ParrelSyncProjectSettings>(ParrelSyncSettingsPath);
+                
+                if (projectSettings == null) 
+                    Debug.LogError("File Exists, but failed to load: " + ParrelSyncSettingsPath);
+                
+                return projectSettings;
+            }
+            
+            projectSettings = CreateInstance<ParrelSyncProjectSettings>();
+            projectSettings.m_OptionalSymbolicLinkFolders = new List<string>();
+            AssetDatabase.CreateAsset(projectSettings, ParrelSyncSettingsPath);
+            AssetDatabase.SaveAssets();
+            return projectSettings;
+        }
+
+        public static SerializedObject GetSerializedSettings()
+        {
+            return new SerializedObject(GetOrCreateSettings());
+        }
+    }
+
+    public class ParrelSyncSettingsProvider : SettingsProvider
+    {
+        private SerializedObject _parrelSyncProjectSettings;
+
+        private class Styles
+        {
+            public static readonly GUIContent SymlinkSectionHeading = new GUIContent("Optional Folders to Symbolically Link");
+        }
+
+        private ParrelSyncSettingsProvider(string path, SettingsScope scope = SettingsScope.User)
+            : base(path, scope)
+        {
+        }
+
+        public override void OnActivate(string searchContext, VisualElement rootElement)
+        {
+            // This function is called when the user clicks on the ParrelSyncSettings element in the Settings window.
+            _parrelSyncProjectSettings = ParrelSyncProjectSettings.GetSerializedSettings();
+        }
+
+        public override void OnGUI(string searchContext)
+        {
+            var property = _parrelSyncProjectSettings.FindProperty("m_OptionalSymbolicLinkFolders");
+            if( property is null || !property.isArray || property.arrayElementType != "string") 
+                return;
+
+            var optionalFolderPaths = new List<string>(property.arraySize);
+            for (var i = 0; i < property.arraySize; ++i)
+            {
+                optionalFolderPaths.Add(property.GetArrayElementAtIndex(i).stringValue);
+            }
+            optionalFolderPaths.Add("");
+            
+            GUILayout.BeginVertical("GroupBox");
+            GUILayout.Label(Styles.SymlinkSectionHeading);
+            GUILayout.Space(5);
+            var projectPath = ClonesManager.GetCurrentProjectPath();
+            var optionalFolderPathsIsDirty = false;
+            for (var i = 0; i < optionalFolderPaths.Count; ++i)
+            {
+                GUILayout.BeginHorizontal();
+                EditorGUILayout.LabelField(optionalFolderPaths[i], EditorStyles.textField, GUILayout.Height(EditorGUIUtility.singleLineHeight));
+                if (GUILayout.Button("Select", GUILayout.Width(60)))
+                {
+                    var result = EditorUtility.OpenFolderPanel("Select Folder to Symbolically Link...", "", "");
+                    if (result.Contains(projectPath))
+                    {
+                        optionalFolderPaths[i] = result.Replace(projectPath,"");
+                        optionalFolderPathsIsDirty = true;
+                    }
+                    else if( result != "")
+                    {
+                        Debug.LogWarning("Symbolic Link folder must be within the project directory");
+                    }
+                }
+                if (GUILayout.Button("Clear", GUILayout.Width(60)))
+                {
+                    optionalFolderPaths[i] = "";
+                    optionalFolderPathsIsDirty = true;
+                }
+                GUILayout.EndHorizontal();
+            }
+            GUILayout.EndVertical();
+
+            if (!optionalFolderPathsIsDirty) 
+                return;
+            
+            optionalFolderPaths.RemoveAll(str=> str == "");
+            property.arraySize = optionalFolderPaths.Count;
+            for (var i = 0; i < property.arraySize; ++i)
+            {
+                property.GetArrayElementAtIndex(i).stringValue = optionalFolderPaths[i];
+            }
+            _parrelSyncProjectSettings.ApplyModifiedProperties();
+            AssetDatabase.SaveAssets();
+        }
+
+        // Register the SettingsProvider
+        [SettingsProvider]
+        public static SettingsProvider CreateParrelSyncSettingsProvider()
+        {
+            return new ParrelSyncSettingsProvider("Project/ParrelSync", SettingsScope.Project)
+            {
+                keywords = GetSearchKeywordsFromGUIContentProperties<Styles>()
+            };
+        }
+    }
+}

--- a/ParrelSync/Editor/ParrelSyncProjectSettings.cs.meta
+++ b/ParrelSync/Editor/ParrelSyncProjectSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0011418c9d75434988a06b6df93b283
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ParrelSync/Editor/Preferences.cs
+++ b/ParrelSync/Editor/Preferences.cs
@@ -114,8 +114,9 @@ namespace ParrelSync
         public static BoolPreference AlsoCheckUnityLockFileStaPref = new BoolPreference("ParrelSync_CheckUnityLockFileOpenStatus", true);
 
         /// <summary>
-        /// In addition of checking the existence of UnityLockFile, 
-        /// also check is the is the UnityLockFile being opened.
+        /// A list of folders to create sybolic links for,
+        /// useful for data that lives outside of the assets folder
+        /// eg. Wwise project data
         /// </summary>
         public static ListOfStringsPreference OptionalSymbolicLinkFolders = new ListOfStringsPreference("ParrelSync_OptionalSymbolicLinkFolders");
         

--- a/ParrelSync/Editor/Preferences.cs
+++ b/ParrelSync/Editor/Preferences.cs
@@ -92,7 +92,7 @@ namespace ParrelSync
             string result = string.Empty;
             foreach (var item in data)
             {
-                if (data.Contains("|"))
+                if (item.Contains("|"))
                 {
                     // throw error
                 }


### PR DESCRIPTION
[edit] added project settings image

Updated the preferences pane to allow users to add additional folders to be symlinked when creating a new clone

![image](https://user-images.githubusercontent.com/6723779/230692299-af37b130-2e29-4289-8b62-6304cd3fcfcf.png)

![image](https://user-images.githubusercontent.com/6723779/232071812-045be7ea-4b9b-4d28-b5c3-9fc74ea19ad1.png)


This provides a solution to both of these issues

[Feature Request] Select extra dependencies on Clone creation https://github.com/VeriorPies/ParrelSync/issues/51
[Feature Request] symbolic link to Library/PackageCache https://github.com/VeriorPies/ParrelSync/issues/67