### PR TITLE
fix: use .NET 2.0 compatible overload (#110)

### DIFF
--- a/ParrelSync/Editor/Preferences.cs
+++ b/ParrelSync/Editor/Preferences.cs
@@ -88,7 +88,7 @@ namespace ParrelSync
         }
         public List<string> Deserialize(string data)
         {
-            return data.Split(serializationToken).ToList();
+            return data.Split(new string[] { serializationToken }, System.StringSplitOptions.None).ToList();
         }
     }
     public class Preferences : EditorWindow


### PR DESCRIPTION
Change the `.ToSplit()` overload to one which is compatible with .NET 2.0, instead of one using a nullable string parameter.

This fixes https://github.com/VeriorPies/ParrelSync/issues/110.