### PR TITLE
fix: modifying the string.Split parameter type

### DIFF
--- a/ParrelSync/Editor/Preferences.cs
+++ b/ParrelSync/Editor/Preferences.cs
@@ -88,7 +88,7 @@ namespace ParrelSync
         }
         public List<string> Deserialize(string data)
         {
-            return data.Split(serializationToken).ToList();
+            return data.Split(serializationToken.ToCharArray()).ToList();
         }
     }
     public class Preferences : EditorWindow


### PR DESCRIPTION
A version of **string.Split** exists that does not accept **string** as a parameter.
Modify the parameter to a **char array** so that it can be used normally in those versions.