### PR TITLE
Fix bug where cloning will fail for project names that start with 'Assets'

### DIFF
--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -437,7 +437,7 @@ namespace ParrelSync
         /// <returns></returns>
         public static string GetCurrentProjectPath()
         {
-            return Application.dataPath.Replace("/Assets", "");
+            return System.IO.Path.GetDirectoryName(Application.dataPath);
         }
 
         /// <summary>


### PR DESCRIPTION
If your Unity project name starts with 'Assets' e.g. 'AssetsProjectToShareWithMyStudents', parrel sync will fail to create clones.  
This will fix the issue by using a more robust method for getting one directory up from Application.dataPath