### PR TITLE
Symlink embedded packages instead of copying

### DIFF
--- a/ParrelSync/Editor/ClonesManager.cs
+++ b/ParrelSync/Editor/ClonesManager.cs
@@ -100,13 +100,14 @@ namespace ParrelSync
 
             ClonesManager.CreateProjectFolder(cloneProject);
 
-            //Copy Folders           
+            //Copy Folders
             Debug.Log("Library copy: " + cloneProject.libraryPath);
             ClonesManager.CopyDirectoryWithProgressBar(sourceProject.libraryPath, cloneProject.libraryPath,
                 "Cloning Project Library '" + sourceProject.name + "'. ");
-            Debug.Log("Packages copy: " + cloneProject.libraryPath);
-            ClonesManager.CopyDirectoryWithProgressBar(sourceProject.packagesPath, cloneProject.packagesPath,
-              "Cloning Project Packages '" + sourceProject.name + "'. ");
+
+            //Packages: copy files, symlink subdirectories
+            Debug.Log("Packages clone: " + cloneProject.packagesPath);
+            ClonesManager.CopyDirectoryWithSymlinkedSubfolders(sourceProject.packagesPath, cloneProject.packagesPath);
 
 
             //Link Folders
@@ -323,6 +324,35 @@ namespace ParrelSync
         }
 
         #endregion
+
+        /// <summary>
+        /// Copies files in the root of the source directory and creates symlinks for subdirectories.
+        /// Used for the Packages folder so that embedded packages are symlinked while manifest files are copied.
+        /// </summary>
+        private static void CopyDirectoryWithSymlinkedSubfolders(string sourcePath, string destinationPath)
+        {
+            if (!Directory.Exists(sourcePath))
+            {
+                Debug.LogWarning("CopyDirectoryWithSymlinkedSubfolders: source path does not exist: " + sourcePath);
+                return;
+            }
+
+            Directory.CreateDirectory(destinationPath);
+
+            // Copy files in the root (manifest.json, packages-lock.json, etc.)
+            foreach (var filePath in Directory.GetFiles(sourcePath))
+            {
+                var fileName = Path.GetFileName(filePath);
+                File.Copy(filePath, Path.Combine(destinationPath, fileName));
+            }
+
+            // Symlink subdirectories (embedded packages)
+            foreach (var dirPath in Directory.GetDirectories(sourcePath))
+            {
+                var dirName = Path.GetFileName(dirPath);
+                LinkFolders(dirPath, Path.Combine(destinationPath, dirName));
+            }
+        }
 
         #region Creating symlinks
 

--- a/ParrelSync/Editor/ValidateCopiedFoldersIntegrity.cs
+++ b/ParrelSync/Editor/ValidateCopiedFoldersIntegrity.cs
@@ -23,7 +23,7 @@ namespace ParrelSync
                 SessionState.SetBool(SessionStateKey, true);
                 if (!ClonesManager.IsClone()) { return; }
 
-                ValidateFolder(ClonesManager.GetCurrentProjectPath(), ClonesManager.GetOriginalProjectPath(), "Packages");
+                ValidatePackagesFiles(ClonesManager.GetCurrentProjectPath(), ClonesManager.GetOriginalProjectPath());
             }
         }
 
@@ -39,6 +39,34 @@ namespace ParrelSync
             {
                 Debug.Log("ParrelSync: Detected changes in '" + folderName + "' directory. Updating cloned project...");
                 FileUtil.ReplaceDirectory(originalFolderPath, targetFolderPath);
+            }
+        }
+
+        /// <summary>
+        /// Validates only the root-level files in the Packages directory (manifest.json, packages-lock.json, etc.).
+        /// Subdirectories are symlinked and don't need validation.
+        /// </summary>
+        public static void ValidatePackagesFiles(string targetRoot, string originalRoot)
+        {
+            var targetPackagesPath = Path.Combine(targetRoot, "Packages");
+            var originalPackagesPath = Path.Combine(originalRoot, "Packages");
+
+            if (!Directory.Exists(originalPackagesPath) || !Directory.Exists(targetPackagesPath))
+                return;
+
+            foreach (var originalFilePath in Directory.GetFiles(originalPackagesPath))
+            {
+                var fileName = Path.GetFileName(originalFilePath);
+                var targetFilePath = Path.Combine(targetPackagesPath, fileName);
+
+                bool needsCopy = !File.Exists(targetFilePath) ||
+                                 File.ReadAllText(originalFilePath) != File.ReadAllText(targetFilePath);
+
+                if (needsCopy)
+                {
+                    Debug.Log("ParrelSync: Detected changes in 'Packages/" + fileName + "'. Updating cloned project...");
+                    File.Copy(originalFilePath, targetFilePath, true);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Embedded package folders directly under `Packages/` are now **symlinked** instead of copied when cloning a project
- Root-level files (`manifest.json`, `packages-lock.json`, etc.) are still copied as before
- Integrity validation updated to only check root-level files (symlinked folders don't need syncing)

## Motivation

When developing local/embedded packages directly under `Packages/`, the current behavior of copying the entire directory means changes in the clone are not reflected in the original project and vice versa. By symlinking the subdirectories, embedded packages are shared between the original and clone, which is essential for library development workflows.

## Test plan

- [ ] Create a clone of a project that has embedded packages under `Packages/`
- [ ] Verify that `manifest.json` and `packages-lock.json` are copied (not symlinked)
- [ ] Verify that package subdirectories under `Packages/` are symlinked
- [ ] Edit a file in an embedded package from the clone and confirm the change appears in the original
- [ ] Reopen the clone and verify that root-level file validation still works correctly